### PR TITLE
Update kafka and add rack

### DIFF
--- a/cluster-up
+++ b/cluster-up
@@ -37,7 +37,8 @@ def add_broker(id)
     'environment' => {
       'kafka_port' => port,
       'kafka_id' => id,
-      'kafka_ip' => HOST_IP
+      'kafka_ip' => HOST_IP,
+      'kafka_rack' => "rack#{id}",
     },
     'hostname' => name,
     'ports' => [ "#{port}:#{port}" ],

--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Andreas Schroeder, https://github.com/andreas-schroeder
 
 # Versions
 ARG scala_version=2.11
-ARG kafka_version=0.10.0.0
+ARG kafka_version=0.10.0.1
 
 # Fetch Kafka & Zookeeper tarfile from apache mirror & extract it to /kafka_<versions-info>.
 RUN \

--- a/kafka/files/bin/start
+++ b/kafka/files/bin/start
@@ -23,6 +23,7 @@ start_kafka() {
   update_config config/server.properties 'port'                 "$kafka_port"
   update_config config/server.properties 'listeners'            "PLAINTEXT://:$kafka_port"
   update_config config/server.properties 'broker.id'            "$kafka_id"
+  update_config config/server.properties 'broker.rack'          "$kafka_rack"
 
   trap "$KAFKA_HOME/bin/kafka-server-stop.sh; echo 'Kafka stopped.'; exit" SIGHUP SIGINT SIGTERM
   bin/kafka-server-start.sh config/server.properties

--- a/kafka/files/config/server.properties
+++ b/kafka/files/config/server.properties
@@ -1,4 +1,5 @@
 broker.id=1
+broker.rack=rack
 
 listeners=PLAINTEXT://:9092
 


### PR DESCRIPTION
This updates the kafka version to `0.10.0.1` and adds support for the `broker.rack` option.
